### PR TITLE
Fix test scripts: override excludedGroups set in POMs

### DIFF
--- a/test-gemini-all.sh
+++ b/test-gemini-all.sh
@@ -4,15 +4,15 @@
 set -e
 
 echo "=== Running gemini-tagged tests in promptkt ==="
-(cd promptkt && mvn test -Dgroups=gemini)
+(cd promptkt && mvn test -Dgroups=gemini -DexcludedGroups=)
 
 echo "=== Running gemini-tagged tests in promptex ==="
-(cd promptex && mvn test -Dgroups=gemini)
+(cd promptex && mvn test -Dgroups=gemini -DexcludedGroups=)
 
 echo "=== Running gemini-tagged tests in promptrt ==="
-(cd promptrt && mvn test -Dgroups=gemini)
+(cd promptrt && mvn test -Dgroups=gemini -DexcludedGroups=)
 
 echo "=== Running gemini-tagged tests in promptfx ==="
-(cd promptfx && mvn test -Dgroups=gemini)
+(cd promptfx && mvn test -Dgroups=gemini -DexcludedGroups=)
 
 echo "=== All gemini-tagged tests completed successfully ==="

--- a/test-openai-all.sh
+++ b/test-openai-all.sh
@@ -4,15 +4,15 @@
 set -e
 
 echo "=== Running openai-tagged tests in promptkt ==="
-(cd promptkt && mvn test -Dgroups=openai)
+(cd promptkt && mvn test -Dgroups=openai -DexcludedGroups=)
 
 echo "=== Running openai-tagged tests in promptex ==="
-(cd promptex && mvn test -Dgroups=openai)
+(cd promptex && mvn test -Dgroups=openai -DexcludedGroups=)
 
 echo "=== Running openai-tagged tests in promptrt ==="
-(cd promptrt && mvn test -Dgroups=openai)
+(cd promptrt && mvn test -Dgroups=openai -DexcludedGroups=)
 
 echo "=== Running openai-tagged tests in promptfx ==="
-(cd promptfx && mvn test -Dgroups=openai)
+(cd promptfx && mvn test -Dgroups=openai -DexcludedGroups=)
 
 echo "=== All openai-tagged tests completed successfully ==="


### PR DESCRIPTION
Each module POM excludes openai/gemini tags by default. Pass -DexcludedGroups= on the command line to clear the exclusion so -Dgroups= filtering actually runs those tests.

https://claude.ai/code/session_01WNBjT57SfvwNyNhusyxFQc