### PR TITLE
Update documentation for Tool/Agent and Task Pipeline APIs

### DIFF
--- a/docs-dev/PromptEx-Task-Pipeline.md
+++ b/docs-dev/PromptEx-Task-Pipeline.md
@@ -1,4 +1,4 @@
-`promptkt-pips` supports creating an executing generic asynchronous task pipelines with dependencies in the package `tri.ai.pips`.
+`promptex-pips` supports creating and executing generic asynchronous task pipelines with dependencies in the package `tri.ai.pips`.
 
 # Basic Example
 
@@ -9,62 +9,64 @@ Here is a sample execution of a chain of three tasks, where we need `Task a` to 
 ```kotlin
     @Test
     fun testExecuteChain() = runTest {
-        val results = AiPipelineExecutor.execute(
-            listOf(GoTask("a"), GoTask("b", setOf("a")), GoTask("c", setOf("b"))),
-            PrintMonitor()).interimResults
-        assertEquals(3, results.size)
-        assertEquals("go", results["a"]?.firstValue!!)
-        assertEquals("go", results["b"]?.firstValue!!)
-        assertEquals("go", results["c"]?.firstValue!!)
+        val result = AiWorkflowExecutor.execute(
+            listOf(GoTask("a"), GoTask("b", setOf("a")), GoTask("c", setOf("b"))))
+        assertEquals(3, result.traces.size)
+        assertEquals("go", result.traces["a"]?.output?.firstValue)
+        assertEquals("go", result.traces["b"]?.output?.firstValue)
+        assertEquals("go", result.traces["c"]?.output?.firstValue)
     }
 
-    class GoTask(id: String, deps: Set<String> = setOf()): AiTask<String>(id, null, deps) {
-        override suspend fun execute(inputs: Map<String, AiPromptTraceSupport<*>>, monitor: AiTaskMonitor) =
-            AiPromptTrace(outputInfo = AiOutputInfo(listOf("go")))
+    class GoTask(id: String, deps: Set<String> = setOf()): AiTask<Any?, String>(id, null, deps) {
+        override suspend fun execute(input: Any?, context: ExecContext) = "go"
     }
 ```
 
-This requires implementing the `AiTask` interface with custom execution logic, and defining the dependencies that must be completed for a task to begin. The `AiPipelineExecutor` handles the ordering of tasks, while the `PrintMonitor` observes progress and reports it as needed.
+This requires implementing the `AiTask` abstract class with custom execution logic, and defining the dependencies that must be completed for a task to begin. `AiWorkflowExecutor` handles the ordering of tasks and shares an `ExecContext` across all tasks; each task's output and trace is stored in the context so subsequent tasks can access them.
 
 # API Details
 
 ## Task Definition
 
-An `AiTask` is required to implement the following:
+`AiTask<I, O>` is an abstract class typed by its input type `I` and output type `O`. It is required to implement:
 
 ```kotlin
     /**
-     * A task that can be executed, using a table of input results indexed by key.
-     * Input types are not specified.
+     * A task that can be executed with a typed input, returning a typed output.
+     * For linear pipelines [input] is the output of the single predecessor task (or null if there is none).
+     * For multi-dependency tasks, all predecessor outputs are available via [ExecContext.get].
+     * Trace information should be recorded via [ExecContext.logTrace] instead of being embedded in the return value.
      */
-    abstract suspend fun execute(inputs: Map<String, AiPromptTraceSupport<*>>, monitor: AiTaskMonitor): AiPromptTraceSupport<T>
+    abstract suspend fun execute(input: I, context: ExecContext): O
 ```
 
-The `AiPromptTraceSupport<T>` object may contain information about the prompt (`AiPromptInfo`), the model (`AiModelInfo`), the execution (`AiExecInfo`), and the output (`AiOutputInfo<T>`). Of these, only execution info is required. This allows tracking of everything from the direct output of the task to errors to prompt and model settings.
+The `ExecContext` provides access to:
+- `context.monitor` — an `AiTaskMonitor` (`FlowCollector<ExecEvent>`) for emitting progress events
+- `context.get(id)` — outputs from previously executed tasks
+- `context.trace(id)` — `AiTaskTrace` objects logged by previously executed tasks
+- `context.logTrace(id, trace)` — records an `AiTaskTrace` for the current task
 
-In general, tasks can be any asynchronous call, and do not need to have any AI-specific code.
+In general, tasks can be any asynchronous call and do not need to have any AI-specific code.
 
 ## Task Execution
 
-`AiPipelineExecutor` is used to execute a list of `AiTask`s. This works by determining which of the remaining tasks have all dependent tasks completed successfully, executing these, and then looking for additional tasks. The `AiTaskMonitor` is notified when the task starts, when it completes successfully, and when it fails.
+`AiWorkflowExecutor` is used to execute a list of `AiTask`s. It works by determining which of the remaining tasks have all dependent tasks completed successfully, executing these, and then looking for additional tasks. Progress events are emitted on `context.monitor` (`AiTaskMonitor`), a `FlowCollector<ExecEvent>`.
 
 ## Linear Task Chain Builder
 
-`AiPlanner` provides a single interface for returning a list of `AiTask`'s and can be used to prepare an execution chain. Builders are provided to assist in creating plans for basic linear task chains, as in the following:
+`AiTaskBuilder` provides a fluent API for building a list of `AiTask`s for a linear execution chain:
 
 ```kotlin
-    override fun plan() =
-        aitask("weather-similarity-check") {
+    val plan: List<AiTask<*, *>> = AiTaskBuilder.task("weather-similarity-check") { context ->
             checkWeatherSimilarity(input)
-        }.aitask("weather-api-request") {
+        }.task("weather-api-request") { similarityResult, context ->
             completionEngine.jsonPromptTask<WeatherRequest>("weather-api-request", input, tokenLimit = 500, temp = null)
-        }.task("weather-api") {
-            weatherService.getWeather(it)
-        }.aitask("weather-response-formatter") {
-            val json = jsonMapper.writeValueAsString(it)
+        }.task("weather-api") { request, context ->
+            weatherService.getWeather(request)
+        }.task("weather-response-formatter") { weatherData, context ->
+            val json = jsonMapper.writeValueAsString(weatherData)
             completionEngine.instructTask("weather-response-formatter", instruct = input, userText = json, tokenLimit = 500, temp = null)
         }.plan
 ```
 
-Here, the first `aitask` is a builder that returns an `AiTaskList` with a single task (executes the functionality between braces). The remaining operations (`aitask` and `task`) add additional tasks to this list, and the final `plan` operation wraps the list within an `AiPlanner` object.
-
+Here, `AiTaskBuilder.task(id) { context -> ... }` creates an `AiTaskBuilder` with a single root task. Each subsequent `.task(id) { input, context -> ... }` adds another task that receives the previous task's output as `input`. The final `.plan` property returns the list of tasks, which can then be passed to `AiWorkflowExecutor.execute()`.

--- a/docs-dev/PromptEx-Tool-Chain.md
+++ b/docs-dev/PromptEx-Tool-Chain.md
@@ -1,57 +1,68 @@
-# Updated Tool/Agent Architecture (0.12.1+)
+# Tool/Agent Architecture
 
-`promptkt-pips` supports agent "planning and execution" through the `tri.ai.core.agent` and `tri.ai.core.tool` packages.
+`promptex-pips` supports agent "planning and execution" through the `tri.ai.core.agent` and `tri.ai.core.tool` packages.
 
 ## Tools
 
 A **tool** is an executable with metadata and structured inputs/outputs. Key interfaces include:
 
-* `tri.ai.core.tool.Executable` defines the core unit of execution, with method signature `fun execute(input: JsonNode, context: ExecContext): JsonNode`
+* `tri.ai.core.tool.Executable` defines the core unit of execution, with method signature `suspend fun execute(input: JsonNode, context: ExecContext): JsonNode`
+
+Concrete base classes:
+* `tri.ai.core.tool.ToolExecutable` — for tools that accept a plain string input and return a string result (`abstract suspend fun run(input: String, context: ExecContext): ToolExecutableResult`)
+* `tri.ai.core.tool.JsonToolExecutable` — for tools with a structured JSON schema input
 
 ## Agent Flows
 
 An **agentic flow** is a means of responding to a user input (e.g. a chat message) with a structured set of tool calls and events. Key interfaces include:
 
 * `tri.ai.core.agent.AgentChat` provides agent chat sessions and associated logging of in-progress events via `AgentChatFlow`
-  * `AgentChatFlow` provides a `Flow<AgentChatEvent>`, where `Flow` is a kotlin coroutine allowing intermediate progress to be "emitted" during execution
-* `tri.ai.core.agent.impl.ToolChainExecutor` (implements `AgentChat`) executes a user request using a set of tools and a "plan and execute" reasoning loop with a chat model
-* `tri.ai.core.agent.impl.JsonToolExecutor` (implements `AgentChat`) executes the same, but using a model API's "tool calling" feature
+  * `AgentChatFlow` wraps a `Flow<AgentChatEvent>` (`AgentChatEvent` is a typealias for `ExecEvent`), where `Flow` is a Kotlin coroutine allowing intermediate progress to be "emitted" during execution
+* `tri.ai.core.agent.impl.ToolChainExecutor` (implements `AgentChat`) executes a user request using a set of tools and a "plan and execute" reasoning loop with a `TextChat` model; takes `List<Executable>` as constructor argument
+* `tri.ai.core.agent.impl.JsonToolExecutor` (implements `AgentChat`) executes the same but using a model API's "tool calling" feature with a `MultimodalChat` model; takes `List<Executable>` as constructor argument
 * `tri.ai.core.agent.wf` provides a more complex reasoning loop, using a set of tools along with further task planning, execution, and validation capabilities
 
 The various execution methods above can be used via the CLI or within the PromptFx UI's *Agentic View*.
 
 --------
 
-# Previous Version (through 0.12.0)
+# Basic Examples
 
-`promptkt-pips` supports "planning and execution" chains through tool selection and use in the package `tri.ai.tools`.
+## Example Tool Implementation
 
-# Basic Example
-
-## Example Tool Use
-
-The `ToolChainExecutor` uses a thought-action-observation template:
+Tools are implemented by extending `ToolExecutable` (for simple string I/O) or `JsonToolExecutable` (for structured JSON I/O):
 
 ```kotlin
-    @Test
-    fun testTools() {
-        OpenAiClient.INSTANCE.settings.logLevel = LogLevel.None
+    val calculator = object : ToolExecutable("Calculator", "Use this to do math") {
+        override suspend fun run(input: String, context: ExecContext) =
+            ToolExecutableResult("42")
+    }
 
-        val tool1 = object : Tool("Calculator", "Use this to do math") {
-            override suspend fun run(input: String) = "42"
-        }
-        val tool2 = object : Tool("Romanizer", "Converts numbers to Roman numerals") {
-            override suspend fun run(input: String) = input.toInt().let {
+    val romanizer = object : ToolExecutable("Romanizer", "Converts numbers to Roman numerals") {
+        override suspend fun run(input: String, context: ExecContext) =
+            ToolExecutableResult(input.toInt().let {
                 when (it) {
                     42 -> "XLII"
                     84 -> "LXXXIV"
                     else -> "I don't know"
                 }
-            }
-        }
+            })
+    }
+```
 
-        ToolChainExecutor(OpenAiCompletionChat())
-            .executeChain("Multiply 21 times 2 and then convert it to Roman numerals.", listOf(tool1, tool2))
+## Example using `ToolChainExecutor`
+
+The `ToolChainExecutor` uses a thought-action-observation template with a `TextChat` model:
+
+```kotlin
+    @Test
+    fun testToolChain() = runBlocking {
+        val tools = listOf(calculator, romanizer)
+        val session = AgentChatSession()
+        val executor = ToolChainExecutor(tools)
+        val flow = executor.sendMessage(session,
+            MultimodalChatMessage.text(MChatRole.User, "Multiply 21 times 2 and then convert it to Roman numerals."))
+        flow.awaitResponseWithLogging()
     }
 ```
 
@@ -70,40 +81,37 @@ INFO: Thought: I now know the final answer
 Final Answer: XLII
 ```
 
-## Example using `JsonFunctionExecutor`
+## Example using `JsonToolExecutor`
 
-The `JsonFunctionExecutor` uses OpenAI's (deprecated) [function API](https://platform.openai.com/docs/api-reference/chat/create#chat-create-functions).
+The `JsonToolExecutor` uses the model API's built-in tool calling feature with a `MultimodalChat` model. Tools with structured JSON schemas can be defined using `JsonToolExecutable`:
 
 ```kotlin
-    @Test
-    fun testTools() {
-        val SAMPLE_TOOL1 = tool("calc", "Use this to do math",
-            """{"type":"object","properties":{"input":{"type":"string"}}}""") {
-            "42"
-        }
-        val SAMPLE_TOOL2 = tool("romanize", "Converts numbers to Roman numerals",
-            """{"type":"object","properties":{"input":{"type":"integer"}}}""") {
-            val value = it["input"]?.jsonPrimitive?.int ?: throw RuntimeException("No input")
-            when (value) {
+    val calcTool = object : JsonToolExecutable("calc", "Use this to do math",
+        """{"type":"object","properties":{"input":{"type":"string"}}}""") {
+        override suspend fun run(input: JsonNode, context: ExecContext) = "42"
+    }
+
+    val romanizeTool = object : JsonToolExecutable("romanize", "Converts numbers to Roman numerals",
+        """{"type":"object","properties":{"input":{"type":"integer"}}}""") {
+        override suspend fun run(input: JsonNode, context: ExecContext): String {
+            val value = input["input"]?.intValue() ?: throw RuntimeException("No input")
+            return when (value) {
                 5 -> "V"
                 42 -> "XLII"
                 84 -> "LXXXIV"
                 else -> "I don't know"
             }
         }
-        val SAMPLE_TOOL4 = tool("other", "Answer a question that cannot be answered by the other tools",
-            """{"type":"object","properties":{"input":{"type":"string"}}}""") {
-            "I don't know"
-        }
-        val SAMPLE_TOOLS = listOf(SAMPLE_TOOL1, SAMPLE_TOOL2, SAMPLE_TOOL4)
+    }
 
-        val exec = JsonFunctionExecutor(OpenAiClient.INSTANCE, GPT35_TURBO, SAMPLE_TOOLS)
-
-        runBlocking {
-            exec.execute("Multiply 21 times 2 and then convert it to Roman numerals.")
-            exec.execute("Convert 5 to a Roman numeral.")
-            exec.execute("What year was Jurassic Park?")
-        }
+    @Test
+    fun testJsonTools() = runBlocking {
+        val tools = listOf(calcTool, romanizeTool)
+        val executor = JsonToolExecutor(tools)
+        val session = AgentChatSession()
+        executor.sendMessage(session,
+            MultimodalChatMessage.text(MChatRole.User, "Multiply 21 times 2 and then convert it to Roman numerals.")
+        ).awaitResponseWithLogging()
     }
 ```
 
@@ -114,51 +122,17 @@ INFO: Call Function: calc with parameters {"input":"21*2"}
 INFO: Result: 42
 INFO: Call Function: romanize with parameters {"input":42}
 INFO: Result: XLII
-INFO: Final Response: The result of multiplying 21 by 2 is 42, which is represented in Roman numerals as XLII.
-INFO: User Question: Convert 5 to a Roman numeral.
-INFO: Call Function: romanize with parameters {"input":5}
-INFO: Result: V
-INFO: Final Response: The Roman numeral equivalent of 5 is V.
-INFO: User Question: What year was Jurassic Park?
-INFO: Final Response: I am unable to provide the release year of Jurassic Park as it requires general knowledge that falls outside the scope of the tools available. You can easily find the information by searching online or consulting a movie database. If you have any other questions related to functions or calculations, feel free to ask!
-```
-
-## Example using `JsonToolExecutor`
-
-The `JsonFunctionExecutor` uses OpenAI's [tool API](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools).
-
-```kotlin
-    @Test
-    fun testTools() {
-        OpenAiClient.INSTANCE.settings.logLevel = LogLevel.None
-
-        runBlocking {
-            JsonToolExecutor(OpenAiClient.INSTANCE, GPT35_TURBO, SAMPLE_TOOLS)
-                .execute("Multiply 21 times 2 and then convert it to Roman numerals.")
-
-            JsonToolExecutor(OpenAiClient.INSTANCE, GPT35_TURBO, SAMPLE_TOOLS)
-                .execute("Convert 5 to a Roman numeral.")
-
-            JsonToolExecutor(OpenAiClient.INSTANCE, GPT35_TURBO, SAMPLE_TOOLS)
-                .execute("What year was Jurassic Park?")
-        }
-    }
-```
-
-Sample output:
-```
-INFO: User Question: Multiply 21 times 2 and then convert it to Roman numerals.
-INFO: Call Function: calc with parameters {"input": "21*2"}
-INFO: Result: 42
-INFO: Call Function: romanize with parameters {"input": 42}
-INFO: Result: XLII
 INFO: Final Response: 21 multiplied by 2 is 42, which is represented in Roman numerals as XLII.
-INFO: User Question: Convert 5 to a Roman numeral.
-INFO: Call Function: romanize with parameters {"input":5}
-INFO: Result: V
-INFO: Final Response: The Roman numeral representation of 5 is "V".
-INFO: User Question: What year was Jurassic Park?
-INFO: Call Function: other with parameters {"input":"Jurassic Park was released in 1993."}
-INFO: Result: I don't know
-INFO: Final Response: I'm unable to provide the exact year for the movie "Jurassic Park". Would you like me to look it up for you?
 ```
+
+--------
+
+# Legacy API (through 0.12.0)
+
+Prior to 0.12.1, `promptkt-pips` used a different tool chain API in the package `tri.ai.tools`:
+- A `Tool` class (now replaced by `Executable`/`ToolExecutable`)
+- `ToolChainExecutor` took a `TextChat` model directly (e.g. `ToolChainExecutor(OpenAiCompletionChat())`) and had an `executeChain(question, tools)` method
+- `JsonFunctionExecutor` used OpenAI's deprecated function calling API (now replaced by `JsonToolExecutor` which uses the tool calling API)
+- `JsonToolExecutor` (old) took an explicit client and model ID (e.g. `JsonToolExecutor(OpenAiClient.INSTANCE, GPT35_TURBO, tools)`)
+
+These classes have been removed. See the current API above.

--- a/docs-dev/PromptKt-Core.md
+++ b/docs-dev/PromptKt-Core.md
@@ -14,10 +14,11 @@ Text/chat models include:
 Special types:
 - `EmbeddingModel` - calculate embedding vector from one or more text strings, with optional dimensionality parameter
 - `ImageGenerator` - generates an image from text, returning image URLs
+- `TextToSpeechModel` - convert text to speech audio
+- `SpeechToTextModel` - transcribe audio to text
 
-Future:
+Partially supported (model type metadata exists, provider implementations may vary):
 - Moderation
-- Audio (text-to-speech, speech-to-text)
 - Responses
 
 Deprecated:
@@ -25,7 +26,9 @@ Deprecated:
 
 ## Model Plugins
 
-`TextPlugin` is a one-stop shop for models from a single provider, supporting the common types above. (This is a legacy name, and would be more descriptive as `AiModelProvider`.) It also provides model metadata as `ModelInfo`.
+`AiModelProvider` is a one-stop shop for models from a single provider, supporting the common types above. It also provides model metadata as `ModelInfo`.
+
+`TextPlugin` is a deprecated typealias for `AiModelProvider`. Prefer using `AiModelProvider` directly.
 
 ## Model Metadata
 


### PR DESCRIPTION
## Summary
This PR updates the documentation to reflect the current state of the Tool/Agent and Task Pipeline APIs, removing outdated information and clarifying the modern API usage patterns.

## Key Changes

### Tool/Agent Architecture Documentation
- Renamed section title from "Updated Tool/Agent Architecture (0.12.1+)" to "Tool/Agent Architecture"
- Updated package name references from `promptkt-pips` to `promptex-pips`
- Added `suspend` keyword to `Executable.execute()` method signature
- Added documentation for concrete base classes:
  - `ToolExecutable` — for simple string I/O tools
  - `JsonToolExecutable` — for structured JSON schema tools
- Clarified `AgentChatFlow` wraps `Flow<AgentChatEvent>` (typealias for `ExecEvent`)
- Updated `ToolChainExecutor` and `JsonToolExecutor` descriptions with constructor argument details and model type requirements
- Completely rewrote example code:
  - Tool implementation examples now use `ToolExecutable` and `JsonToolExecutable` base classes
  - Updated `ToolChainExecutor` example to use `AgentChatSession`, `MultimodalChatMessage`, and `awaitResponseWithLogging()`
  - Updated `JsonToolExecutor` example with modern API patterns
- Moved legacy API information (0.12.0 and earlier) to a separate "Legacy API" section at the end with brief migration notes

### Task Pipeline Documentation
- Fixed typo: "creating an executing" → "creating and executing"
- Updated package name from `promptkt-pips` to `promptex-pips`
- Completely rewrote example code:
  - Changed from `AiPipelineExecutor` to `AiWorkflowExecutor`
  - Updated `AiTask` to use new generic type parameters `AiTask<I, O>`
  - Changed `execute()` signature from `execute(inputs: Map<String, AiPromptTraceSupport<*>>, monitor: AiTaskMonitor)` to `execute(input: I, context: ExecContext)`
  - Updated result access pattern from `interimResults` to `result.traces`
- Updated API Details section:
  - Clarified `AiTask` is an abstract class with typed input/output
  - Documented `ExecContext` API for accessing task outputs, traces, and emitting events
  - Updated `AiWorkflowExecutor` description
- Rewrote Linear Task Chain Builder section:
  - Changed from `AiPlanner` to `AiTaskBuilder`
  - Updated fluent API examples with new method signatures
  - Clarified how task inputs flow through the chain

### Core Model Documentation
- Added `TextToSpeechModel` and `SpeechToTextModel` to special types list
- Moved Audio support from "Future" to "Partially supported" section
- Renamed `TextPlugin` to `AiModelProvider` as the primary name
- Added note that `TextPlugin` is a deprecated typealias

https://claude.ai/code/session_016AiaPojd4T8xxVPeHfD9Jj