### PR TITLE
Bump version to 0.16.0

### DIFF
--- a/distribution/build.gradle.kts
+++ b/distribution/build.gradle.kts
@@ -3,10 +3,10 @@ plugins {
 }
 
 group = "com.googlecode.blaisemath"
-version = "0.15.0"
+version = "0.16.0"
 
 val appName = "promptfx"
-val appVersion = "0.15.0"
+val appVersion = "0.16.0"
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
## Summary
This release updates the project version from 0.15.0 to 0.16.0.

## Changes
- Updated `group` version in `distribution/build.gradle.kts` from 0.15.0 to 0.16.0
- Updated `appVersion` in `distribution/build.gradle.kts` from 0.15.0 to 0.16.0

This is a minor version bump indicating new features or improvements have been added to the promptfx application.

https://claude.ai/code/session_01QkPJxVDUcaPa9oAn9bhVJU