### PR TITLE
feat: expand sample provider to demonstrate all seven model capabilit…

### DIFF
--- a/promptkt/promptkt-provider-sample/src/main/kotlin/tri/promptfx/sample/textplugin/SampleAiModelProvider.kt
+++ b/promptkt/promptkt-provider-sample/src/main/kotlin/tri/promptfx/sample/textplugin/SampleAiModelProvider.kt
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,12 +23,22 @@ import tri.ai.core.*
 import tri.ai.prompt.trace.AiEnvInfo
 import tri.ai.prompt.trace.AiExecInfo
 import tri.ai.prompt.trace.AiModelInfo
+import tri.ai.prompt.trace.AiOutput
 import tri.ai.prompt.trace.AiOutputInfo
 import tri.ai.prompt.trace.AiTaskTrace
+import java.io.File
+import java.net.URI
 
-/** 
+/**
  * Sample plugin demonstrating [AiModelProvider] implementation.
- * This provides a simple echo-based AI model for demonstration purposes.
+ *
+ * Provides stub implementations of all seven model capability types. Use this as a template
+ * when creating a new provider — replace each stub with real API calls and update [modelInfo]
+ * with accurate metadata. Register the provider class name in:
+ *   META-INF/services/tri.ai.core.AiModelProvider
+ *
+ * Providers that do not support a capability type should return [emptyList] for that method
+ * (the default in [AiModelProvider]); do NOT return a model that throws on every call.
  */
 class SampleAiModelProvider : AiModelProvider {
 
@@ -37,41 +47,62 @@ class SampleAiModelProvider : AiModelProvider {
     override fun modelSource() = MODEL_SOURCE
 
     override fun modelInfo() = listOf(
-        ModelInfo("sample-echo-v1", ModelType.TEXT_COMPLETION, modelSource()).apply {
-            metadata.name = "Sample Echo Model"
-            metadata.description = "A simple echo model that returns the input text with a prefix"
+        ModelInfo("sample-chat-v1", ModelType.TEXT_CHAT, modelSource()).apply {
+            metadata.name = "Sample Chat Model"
+            metadata.description = "Echoes the last user message"
             params["inputTokenLimit"] = 1000
             params["outputTokenLimit"] = 1000
         },
-        ModelInfo("sample-chat-v1", ModelType.TEXT_CHAT, modelSource()).apply {
-            metadata.name = "Sample Chat Model"
-            metadata.description = "A simple chat model that echoes messages"
+        ModelInfo("sample-multimodal-v1", ModelType.TEXT_CHAT, modelSource()).apply {
+            metadata.name = "Sample Multimodal Model"
+            metadata.description = "Echoes text content from multimodal messages"
             params["inputTokenLimit"] = 1000
             params["outputTokenLimit"] = 1000
+        },
+        ModelInfo("sample-echo-v1", ModelType.TEXT_COMPLETION, modelSource()).apply {
+            metadata.name = "Sample Completion Model"
+            metadata.description = "Echoes the input text with a prefix"
+            params["inputTokenLimit"] = 1000
+            params["outputTokenLimit"] = 1000
+        },
+        ModelInfo("sample-embedding-v1", ModelType.TEXT_EMBEDDING, modelSource()).apply {
+            metadata.name = "Sample Embedding Model"
+            metadata.description = "Returns a fixed-size zero vector for each input"
+            params["outputDimensionality"] = EMBEDDING_DIM
+        },
+        ModelInfo("sample-image-v1", ModelType.IMAGE_GENERATOR, modelSource()).apply {
+            metadata.name = "Sample Image Generator"
+            metadata.description = "Returns a placeholder data: URI"
+        },
+        ModelInfo("sample-tts-v1", ModelType.TEXT_TO_SPEECH, modelSource()).apply {
+            metadata.name = "Sample TTS Model"
+            metadata.description = "Returns empty audio bytes"
+        },
+        ModelInfo("sample-stt-v1", ModelType.SPEECH_TO_TEXT, modelSource()).apply {
+            metadata.name = "Sample STT Model"
+            metadata.description = "Returns a fixed placeholder transcription"
         }
     )
 
-    override fun embeddingModels() = emptyList<EmbeddingModel>()
-
     override fun chatModels() = listOf(SampleChatModel())
-
-    override fun multimodalModels() = emptyList<MultimodalChat>()
-
+    override fun multimodalModels() = listOf(SampleMultimodalChatModel())
     override fun textCompletionModels() = listOf(SampleTextCompletionModel())
+    override fun embeddingModels() = listOf(SampleEmbeddingModel())
+    override fun imageGeneratorModels() = listOf(SampleImageGenerator())
+    override fun textToSpeechModels() = listOf(SampleTextToSpeechModel())
+    override fun speechToTextModels() = listOf(SampleSpeechToTextModel())
 
-    override fun imageGeneratorModels() = emptyList<ImageGenerator>()
-
-    override fun close() {
-        // No resources to close
-    }
+    override fun close() { }
 
     companion object {
-        /** Model source identifier for the SampleText plugin. */
         const val MODEL_SOURCE = "SampleText"
+        const val EMBEDDING_DIM = 8
     }
 }
 
-/** Sample text completion model that echoes input with a prefix. */
+// --- TextCompletion ---
+
+/** Echoes input text with a prefix. */
 class SampleTextCompletionModel : TextCompletion {
     override val modelId = "sample-echo-v1"
     override val modelSource = SampleAiModelProvider.MODEL_SOURCE
@@ -83,17 +114,16 @@ class SampleTextCompletionModel : TextCompletion {
         tokens: Int?,
         stop: List<String>?,
         numResponses: Int?
-    ): AiTaskTrace {
-        val response = "Sample Echo: $text"
-        return AiTaskTrace(
-            env = AiEnvInfo(AiModelInfo(modelId)),
-            exec = AiExecInfo(),
-            output = AiOutputInfo.text(response)
-        )
-    }
+    ): AiTaskTrace = AiTaskTrace(
+        env = AiEnvInfo(AiModelInfo(modelId)),
+        exec = AiExecInfo(),
+        output = AiOutputInfo.text("Sample Echo: $text")
+    )
 }
 
-/** Sample chat model that echoes the last message. */
+// --- TextChat ---
+
+/** Echoes the last user message as an assistant reply. */
 class SampleChatModel : TextChat {
     override val modelId = "sample-chat-v1"
     override val modelSource = SampleAiModelProvider.MODEL_SOURCE
@@ -107,12 +137,107 @@ class SampleChatModel : TextChat {
         numResponses: Int?,
         requestJson: Boolean?
     ): AiTaskTrace {
-        val lastMessage = messages.lastOrNull()?.content ?: "No message provided"
-        val response = TextChatMessage(MChatRole.Assistant, "Sample response to: $lastMessage")
+        val last = messages.lastOrNull()?.content ?: "No message provided"
+        val reply = TextChatMessage(MChatRole.Assistant, "Sample response to: $last")
         return AiTaskTrace(
             env = AiEnvInfo(AiModelInfo(modelId)),
             exec = AiExecInfo(),
-            output = AiOutputInfo.messages(listOf(response))
+            output = AiOutputInfo.messages(listOf(reply))
         )
     }
+}
+
+// --- MultimodalChat ---
+
+/** Echoes text content extracted from the last multimodal message. */
+class SampleMultimodalChatModel : MultimodalChat {
+    override val modelId = "sample-multimodal-v1"
+    override val modelSource = SampleAiModelProvider.MODEL_SOURCE
+    override fun toString() = modelDisplayName()
+
+    override suspend fun chat(
+        messages: List<MultimodalChatMessage>,
+        parameters: MChatParameters
+    ): AiTaskTrace {
+        val lastText = messages.lastOrNull()
+            ?.content?.filterIsInstance<MChatMessagePart>()
+            ?.firstOrNull { it.partType == MPartType.TEXT }
+            ?.text ?: "No text content"
+        val reply = MultimodalChatMessage.text(MChatRole.Assistant, "Sample multimodal response to: $lastText")
+        return AiTaskTrace(
+            env = AiEnvInfo(AiModelInfo(modelId)),
+            exec = AiExecInfo(),
+            output = AiOutputInfo.multimodalMessage(reply)
+        )
+    }
+
+    override suspend fun chat(message: MultimodalChatMessage, parameters: MChatParameters) =
+        chat(listOf(message), parameters)
+
+    override fun close() { }
+}
+
+// --- EmbeddingModel ---
+
+/** Returns a zero vector of fixed dimensionality for each input string. */
+class SampleEmbeddingModel : EmbeddingModel {
+    override val modelId = "sample-embedding-v1"
+    override val modelSource = SampleAiModelProvider.MODEL_SOURCE
+    override fun toString() = modelDisplayName()
+
+    override suspend fun calculateEmbedding(
+        text: List<String>,
+        outputDimensionality: Int?
+    ): List<List<Double>> {
+        val dim = outputDimensionality ?: SampleAiModelProvider.EMBEDDING_DIM
+        return text.map { List(dim) { 0.0 } }
+    }
+}
+
+// --- ImageGenerator ---
+
+/** Returns a 1×1 transparent PNG as a data: URI for each requested image. */
+class SampleImageGenerator : ImageGenerator {
+    override val modelId = "sample-image-v1"
+    override val modelSource = SampleAiModelProvider.MODEL_SOURCE
+    override fun toString() = modelDisplayName()
+
+    override suspend fun generateImage(text: String, params: ImageGenerationParams): List<URI> {
+        val count = params.numResponses ?: 1
+        // 1×1 transparent PNG (base64-encoded)
+        val placeholder = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        return List(count) { URI.create(placeholder) }
+    }
+}
+
+// --- TextToSpeechModel ---
+
+/** Returns an empty ByteArray as the audio output. */
+class SampleTextToSpeechModel : TextToSpeechModel {
+    override val modelId = "sample-tts-v1"
+    override val modelSource = SampleAiModelProvider.MODEL_SOURCE
+    override fun toString() = modelDisplayName()
+
+    override suspend fun speech(text: String, voice: String?, speed: Double?): AiTaskTrace =
+        AiTaskTrace(
+            env = AiEnvInfo(AiModelInfo(modelId)),
+            exec = AiExecInfo(),
+            output = AiOutputInfo.output(AiOutput.Other(ByteArray(0)))
+        )
+}
+
+// --- SpeechToTextModel ---
+
+/** Returns a fixed placeholder transcription regardless of input file. */
+class SampleSpeechToTextModel : SpeechToTextModel {
+    override val modelId = "sample-stt-v1"
+    override val modelSource = SampleAiModelProvider.MODEL_SOURCE
+    override fun toString() = modelDisplayName()
+
+    override suspend fun transcribe(audioFile: File, prompt: String?): AiTaskTrace =
+        AiTaskTrace(
+            env = AiEnvInfo(AiModelInfo(modelId)),
+            exec = AiExecInfo(),
+            output = AiOutputInfo.text("Sample transcription of: ${audioFile.name}")
+        )
 }

--- a/promptkt/promptkt-provider-sample/src/test/kotlin/tri/promptfx/sample/textplugin/SampleAiModelProviderTest.kt
+++ b/promptkt/promptkt-provider-sample/src/test/kotlin/tri/promptfx/sample/textplugin/SampleAiModelProviderTest.kt
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,94 +20,157 @@
 package tri.promptfx.sample.textplugin
 
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 import tri.ai.core.*
 import tri.ai.prompt.trace.AiOutput
+import java.io.File
 import java.util.*
 
 class SampleAiModelProviderTest {
 
+    private val plugin = SampleAiModelProvider()
+
+    // --- Provider registration ---
+
     @Test
-    fun `plugin should be discoverable via ServiceLoader`() {
-        val loader = ServiceLoader.load(AiModelProvider::class.java)
-        val plugins = loader.toList()
-        
-        val samplePlugin = plugins.find { it is SampleAiModelProvider }
-        assertNotNull(samplePlugin, "SampleAiModelProvider should be discoverable via ServiceLoader")
+    fun `plugin is discoverable via ServiceLoader`() {
+        val plugins = ServiceLoader.load(AiModelProvider::class.java).toList()
+        assertNotNull(plugins.find { it is SampleAiModelProvider })
     }
 
     @Test
-    fun `plugin should have correct model source`() {
-        val plugin = SampleAiModelProvider()
+    fun `plugin has correct model source`() {
         assertEquals("SampleText", plugin.modelSource())
     }
 
     @Test
-    fun `plugin should provide model info`() {
-        val plugin = SampleAiModelProvider()
-        val modelInfo = plugin.modelInfo()
-        
-        assertEquals(2, modelInfo.size)
-        assertTrue(modelInfo.any { it.id == "sample-echo-v1" })
-        assertTrue(modelInfo.any { it.id == "sample-chat-v1" })
+    fun `modelInfo covers all seven capability types`() {
+        val types = plugin.modelInfo().map { it.type }.toSet()
+        assertTrue(ModelType.TEXT_CHAT in types)
+        assertTrue(ModelType.TEXT_COMPLETION in types)
+        assertTrue(ModelType.TEXT_EMBEDDING in types)
+        assertTrue(ModelType.IMAGE_GENERATOR in types)
+        assertTrue(ModelType.TEXT_TO_SPEECH in types)
+        assertTrue(ModelType.SPEECH_TO_TEXT in types)
+    }
+
+    // --- TextCompletion ---
+
+    @Test
+    fun `textCompletionModels returns one model`() {
+        assertEquals(1, plugin.textCompletionModels().size)
     }
 
     @Test
-    fun `plugin should provide chat model`() {
-        val plugin = SampleAiModelProvider()
-        val chatModels = plugin.chatModels()
-        
-        assertEquals(1, chatModels.size)
-        assertEquals("sample-chat-v1", chatModels[0].modelId)
+    fun `text completion echoes input`() = runBlocking {
+        val result = SampleTextCompletionModel().complete("Hello")
+        assertTrue(result.exec.succeeded())
+        assertEquals("Sample Echo: Hello", result.firstValue.textContent())
+    }
+
+    // --- TextChat ---
+
+    @Test
+    fun `chatModels returns one model`() {
+        assertEquals(1, plugin.chatModels().size)
     }
 
     @Test
-    fun `plugin should provide text completion model`() {
-        val plugin = SampleAiModelProvider()
-        val completionModels = plugin.textCompletionModels()
-        
-        assertEquals(1, completionModels.size)
-        assertEquals("sample-echo-v1", completionModels[0].modelId)
+    fun `chat model echoes last message`() = runBlocking {
+        val messages = listOf(TextChatMessage(MChatRole.User, "Test message"))
+        val result = SampleChatModel().chat(messages)
+        assertTrue(result.exec.succeeded())
+        val reply = (result.firstValue as? AiOutput.ChatMessage)?.message
+        assertNotNull(reply)
+        assertEquals(MChatRole.Assistant, reply?.role)
+        assertTrue(reply?.content?.contains("Test message") == true)
+    }
+
+    // --- MultimodalChat ---
+
+    @Test
+    fun `multimodalModels returns one model`() {
+        assertEquals(1, plugin.multimodalModels().size)
     }
 
     @Test
-    fun `text completion model should echo input`() = runBlocking {
-        val model = SampleTextCompletionModel()
-        val result = model.complete("Hello World", MChatVariation(), null, null, null)
-        
-        assertEquals("Sample Echo: Hello World", result.firstValue.textContent())
+    fun `multimodal model echoes text content`() = runBlocking {
+        val message = MultimodalChatMessage.text(MChatRole.User, "Hello multimodal")
+        val result = SampleMultimodalChatModel().chat(message)
+        assertTrue(result.exec.succeeded())
+        assertTrue(result.firstValue.textContent().contains("Hello multimodal"))
+    }
+
+    // --- EmbeddingModel ---
+
+    @Test
+    fun `embeddingModels returns one model`() {
+        assertEquals(1, plugin.embeddingModels().size)
     }
 
     @Test
-    fun `chat model should respond to messages`() = runBlocking {
-        val model = SampleChatModel()
-        val messages = listOf(
-            TextChatMessage(MChatRole.User, "Test message")
-        )
-        val result = model.chat(messages, MChatVariation(), null, null, null, null)
-        
-        val response = (result.firstValue as? AiOutput.ChatMessage)?.message
-        assertNotNull(response)
-        assertEquals(MChatRole.Assistant, response?.role)
-        assertTrue(response?.content?.contains("Test message") == true)
+    fun `embedding model returns zero vector of correct dimensionality`() = runBlocking {
+        val result = SampleEmbeddingModel().calculateEmbedding(listOf("a", "b"))
+        assertEquals(2, result.size)
+        assertEquals(SampleAiModelProvider.EMBEDDING_DIM, result[0].size)
+        assertTrue(result[0].all { it == 0.0 })
     }
 
     @Test
-    fun `plugin should have empty embedding models`() {
-        val plugin = SampleAiModelProvider()
-        assertTrue(plugin.embeddingModels().isEmpty())
+    fun `embedding model respects custom dimensionality`() = runBlocking {
+        val result = SampleEmbeddingModel().calculateEmbedding(listOf("x"), outputDimensionality = 16)
+        assertEquals(16, result[0].size)
+    }
+
+    // --- ImageGenerator ---
+
+    @Test
+    fun `imageGeneratorModels returns one model`() {
+        assertEquals(1, plugin.imageGeneratorModels().size)
     }
 
     @Test
-    fun `plugin should have empty multimodal models`() {
-        val plugin = SampleAiModelProvider()
-        assertTrue(plugin.multimodalModels().isEmpty())
+    fun `image generator returns data URI`() = runBlocking {
+        val uris = SampleImageGenerator().generateImage("a dog")
+        assertEquals(1, uris.size)
+        assertTrue(uris[0].toString().startsWith("data:image/png;base64,"))
     }
 
     @Test
-    fun `plugin should have empty image generator models`() {
-        val plugin = SampleAiModelProvider()
-        assertTrue(plugin.imageGeneratorModels().isEmpty())
+    fun `image generator respects numResponses`() = runBlocking {
+        val uris = SampleImageGenerator().generateImage("a cat", ImageGenerationParams(numResponses = 3))
+        assertEquals(3, uris.size)
+    }
+
+    // --- TextToSpeechModel ---
+
+    @Test
+    fun `textToSpeechModels returns one model`() {
+        assertEquals(1, plugin.textToSpeechModels().size)
+    }
+
+    @Test
+    fun `tts model returns successful trace with byte array output`() = runBlocking {
+        val result = SampleTextToSpeechModel().speech("Hello")
+        assertTrue(result.exec.succeeded())
+        val audio = (result.firstValue as? AiOutput.Other)?.other
+        assertNotNull(audio)
+        assertTrue(audio is ByteArray)
+    }
+
+    // --- SpeechToTextModel ---
+
+    @Test
+    fun `speechToTextModels returns one model`() {
+        assertEquals(1, plugin.speechToTextModels().size)
+    }
+
+    @Test
+    fun `stt model returns transcription containing filename`() = runBlocking {
+        val file = File("test-audio.wav")
+        val result = SampleSpeechToTextModel().transcribe(file)
+        assertTrue(result.exec.succeeded())
+        assertTrue(result.firstValue.textContent().contains("test-audio.wav"))
     }
 }


### PR DESCRIPTION
…y types

Previously only TextCompletion and TextChat were implemented, making the sample an incomplete template for new provider authors. Now all seven types are stubbed with realistic patterns:

- SampleMultimodalChatModel: echoes text from multimodal message parts
- SampleEmbeddingModel: returns zero vectors of configurable dimensionality
- SampleImageGenerator: returns a 1x1 transparent PNG as a data: URI
- SampleTextToSpeechModel: returns empty ByteArray in AiOutput.Other
- SampleSpeechToTextModel: returns transcription string with filename

KDoc clarifies that unsupported capabilities should return emptyList(), not a model that throws on every call.

Tests expanded from 11 to 19, covering all seven types.